### PR TITLE
Adding SIMplyBee for honeybee breeding simultations

### DIFF
--- a/Agriculture.md
+++ b/Agriculture.md
@@ -186,7 +186,7 @@ See the R package repository [Bioconductor](https://www.bioconductor.org/) for b
 
 -   `r pkg("selection.index")` calculates a selection index using the method described by Smith ([1936](https://onlinelibrary.wiley.com/doi/10.1111/j.1469-1809.1936.tb02143.x)).
 
--   *Breeding simulations* `r pkg("AlphaSimR")` is an implementation of the [AlphaSim algorithm](https://doi.org/10.3835%2Fplantgenome2016.02.0013) in R, providing functions for stochastic modelling of processes common to breeding programs such as selection and crossing. `r github("tpook92/MoBPS")` has a suite of functions for simulating genetic gain and economic costs in a plant breeding program. 
+-   *Breeding simulations* `r pkg("AlphaSimR")` provides functions for stochastic modelling of processes common to breeding programs such as selection and crossing, in plant or animals [Gaynor et al. 2020](https://doi.org/10.1093/g3journal/jkaa017). `r pkg("SIMplyBee")` is an extension of AlphaSimR for honeybees [Obsteter et al. 2023](https://doi.org/10.1186/s12711-023-00798-y). `r pkg("MoBPS")` also provides functions for stochastic modelling of breeding programs [Pook et al. 2020](https://doi.org/10.1534/g3.120.401193).
 
 #### [Linkage mapping & QTL analysis]{#qtl}
 


### PR DESCRIPTION
@jpiaskowski I have added SIMplyBee R package for honeybee breeding simulations https://doi.org/10.1186/s12711-023-00798-y and have polished citations for AlphaSimR and MoBPS.